### PR TITLE
Handle unexpected responses

### DIFF
--- a/src/__test__/get-error.ts
+++ b/src/__test__/get-error.ts
@@ -1,0 +1,16 @@
+class NoErrorThrownError extends Error {}
+
+/**
+ * This helper function is used to test that a function throws an error.
+ * The caught error is returned so that it can be inspected.
+ * If the function does not throw an error, a `NoErrorThrownError` is thrown.
+ */
+export async function getError(call: () => unknown): Promise<unknown> {
+  try {
+    await call();
+
+    throw new NoErrorThrownError();
+  } catch (error: unknown) {
+    return error;
+  }
+}

--- a/src/__test__/scenario.ts
+++ b/src/__test__/scenario.ts
@@ -10,7 +10,7 @@ export interface RequestResponsePair {
     body?: any;
   };
   response: {
-    headers: Record<string, string>;
+    headers: Record<string, string | string[]>;
     body?: any;
     status: number;
 

--- a/src/__test__/scenarios/multiple-pages.ts
+++ b/src/__test__/scenarios/multiple-pages.ts
@@ -23,6 +23,7 @@ export const multiplePages = {
       headers: {},
       status: 200,
       body: {
+        status: 200,
         cookies: {
           "session-id": "2",
         },
@@ -55,6 +56,7 @@ export const multiplePages = {
       headers: {},
       status: 200,
       body: {
+        status: 200,
         cookies: {
           "session-id": "2",
         },

--- a/src/__test__/scenarios/signin-redirect.ts
+++ b/src/__test__/scenarios/signin-redirect.ts
@@ -1,0 +1,19 @@
+import { TLSClientResponseData } from "../../kindle";
+import { unexpectedResponse } from "./unexpected-response";
+
+export function signinRedirect() {
+  const response = {
+    headers: {
+      Location: [
+        "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=1209600&openid.return_to=foobar",
+      ],
+    },
+    status: 302,
+    body: "{}",
+    cookies: {},
+    target:
+      "https://read.amazon.com/kindle-library/search?query=&libraryType=BOOKS&sortType=acquisition_desc&querySize=50",
+  } satisfies TLSClientResponseData;
+
+  return unexpectedResponse({ response });
+}

--- a/src/__test__/scenarios/signin-redirect.ts
+++ b/src/__test__/scenarios/signin-redirect.ts
@@ -1,5 +1,5 @@
-import { TLSClientResponseData } from "../../kindle";
-import { unexpectedResponse } from "./unexpected-response";
+import { TLSClientResponseData } from "../../kindle.js";
+import { unexpectedResponse } from "./unexpected-response.js";
 
 export function signinRedirect() {
   const response = {
@@ -15,5 +15,5 @@ export function signinRedirect() {
       "https://read.amazon.com/kindle-library/search?query=&libraryType=BOOKS&sortType=acquisition_desc&querySize=50",
   } satisfies TLSClientResponseData;
 
-  return unexpectedResponse({ response });
+  return unexpectedResponse({ startSessionResponse: response });
 }

--- a/src/__test__/scenarios/single-book.ts
+++ b/src/__test__/scenarios/single-book.ts
@@ -23,6 +23,7 @@ export const singleBook = {
       headers: {},
       status: 200,
       body: {
+        status: 200,
         cookies: {
           "session-id": "2",
         },
@@ -54,6 +55,7 @@ export const singleBook = {
       headers: {},
       status: 200,
       body: {
+        status: 200,
         cookies: {
           "session-id": "2",
         },

--- a/src/__test__/scenarios/single-page.ts
+++ b/src/__test__/scenarios/single-page.ts
@@ -23,6 +23,7 @@ export const singlePages = {
       headers: {},
       status: 200,
       body: {
+        status: 200,
         cookies: {
           "session-id": "2",
         },

--- a/src/__test__/scenarios/start-session.ts
+++ b/src/__test__/scenarios/start-session.ts
@@ -20,6 +20,7 @@ export function startSession({ books }: { books?: KindleBookData[] } = {}) {
         headers: {},
         status: 200,
         body: {
+          status: 200,
           cookies: {
             "session-id": "2",
           },
@@ -50,6 +51,7 @@ export function startSession({ books }: { books?: KindleBookData[] } = {}) {
         status: 200,
         headers: {},
         body: {
+          status: 200,
           cookies: {
             "session-id": faker.string.uuid(),
           },

--- a/src/__test__/scenarios/unexpected-response.ts
+++ b/src/__test__/scenarios/unexpected-response.ts
@@ -1,0 +1,31 @@
+import { TLSClientResponseData } from "../../kindle";
+import { Scenario } from "../scenario";
+import { defaultRequestBody } from "./fixtures/default-request-body";
+
+export function unexpectedResponse({
+  response,
+}: {
+  response: TLSClientResponseData;
+}) {
+  return {
+    startSession: {
+      request: {
+        method: "post",
+        url: "http://localhost:8080/api/forward",
+        body: {
+          ...defaultRequestBody,
+          requestUrl:
+            "https://read.amazon.com/kindle-library/search?query=&libraryType=BOOKS&sortType=acquisition_desc&querySize=50",
+        },
+      },
+      response: {
+        headers: {},
+        status: 200,
+        body: response,
+        meta: {
+          response,
+        },
+      },
+    },
+  } satisfies Scenario;
+}

--- a/src/__test__/scenarios/unexpected-response.ts
+++ b/src/__test__/scenarios/unexpected-response.ts
@@ -1,11 +1,18 @@
-import { TLSClientResponseData } from "../../kindle";
-import { Scenario } from "../scenario";
-import { defaultRequestBody } from "./fixtures/default-request-body";
+import { faker } from "@faker-js/faker";
+import { TLSClientResponseData } from "../../kindle.js";
+import { Scenario } from "../scenario.js";
+import { sample1, sample1Details, sample1MetaData } from "./fixtures/books.js";
+import { defaultRequestBody } from "./fixtures/default-request-body.js";
+import { sessionToken } from "./fixtures/tokens.js";
 
 export function unexpectedResponse({
-  response,
+  startSessionResponse,
+  getBookDetailsResponse,
+  getBookMetaDataResponse,
 }: {
-  response: TLSClientResponseData;
+  startSessionResponse?: TLSClientResponseData;
+  getBookDetailsResponse?: TLSClientResponseData;
+  getBookMetaDataResponse?: TLSClientResponseData;
 }) {
   return {
     startSession: {
@@ -21,9 +28,109 @@ export function unexpectedResponse({
       response: {
         headers: {},
         status: 200,
-        body: response,
+        body: startSessionResponse ?? {
+          status: 200,
+          cookies: {
+            "session-id": "2",
+          },
+          body: JSON.stringify({
+            itemsList: [sample1],
+          }),
+        },
         meta: {
-          response,
+          response: startSessionResponse,
+        },
+      },
+    },
+    getDeviceToken: {
+      request: {
+        method: "post",
+        url: "http://localhost:8080/api/forward",
+        body: {
+          ...defaultRequestBody,
+          requestUrl:
+            "https://read.amazon.com/service/web/register/getDeviceToken?serialNumber=bar&deviceType=bar",
+          headers: {
+            ...defaultRequestBody.headers,
+            "x-amzn-sessionid": "2",
+          },
+        },
+      },
+      response: {
+        status: 200,
+        headers: {},
+        body: {
+          status: 200,
+          cookies: {
+            "session-id": faker.string.uuid(),
+          },
+          body: JSON.stringify({
+            clientHashId: faker.string.uuid(),
+            deviceName: faker.lorem.word(),
+            deviceSessionToken: sessionToken,
+            eid: faker.string.uuid(),
+          }),
+        },
+      },
+    },
+    getBookDetails: {
+      request: {
+        method: "post",
+        url: "http://localhost:8080/api/forward",
+        body: {
+          ...defaultRequestBody,
+          requestUrl:
+            "https://read.amazon.com/service/mobile/reader/startReading?asin=B000FBJG4U&clientVersion=2000010",
+          headers: {
+            ...defaultRequestBody.headers,
+            "x-amzn-sessionid": "2",
+            "x-adp-session-token": sessionToken,
+          },
+        },
+      },
+      response: {
+        headers: {},
+        status: 200,
+        body: getBookDetailsResponse ?? {
+          status: 200,
+          cookies: {
+            "session-id": "2",
+          },
+          body: JSON.stringify({
+            ...sample1Details,
+          }),
+        },
+        meta: {
+          books: [sample1],
+        },
+      },
+    },
+    getBookMetaData: {
+      request: {
+        method: "post",
+        url: "http://localhost:8080/api/forward",
+        body: {
+          ...defaultRequestBody,
+          requestUrl:
+            "https://read.amazon.com/service/metadata/lookup?asin=B000FBJG4U&metadataVersion=1",
+          headers: {
+            ...defaultRequestBody.headers,
+            "x-amzn-sessionid": "2",
+            "x-adp-session-token": sessionToken,
+          },
+        },
+      },
+      response: {
+        headers: {},
+        status: 200,
+        body: getBookMetaDataResponse ?? {
+          status: 200,
+          cookies: {
+            "session-id": "2",
+          },
+          body: `(${JSON.stringify({
+            ...sample1MetaData,
+          })})`,
         },
       },
     },

--- a/src/__test__/scenarios/unexpected-response.ts
+++ b/src/__test__/scenarios/unexpected-response.ts
@@ -9,10 +9,12 @@ export function unexpectedResponse({
   startSessionResponse,
   getBookDetailsResponse,
   getBookMetaDataResponse,
+  getDeviceTokenResponse,
 }: {
   startSessionResponse?: TLSClientResponseData;
   getBookDetailsResponse?: TLSClientResponseData;
   getBookMetaDataResponse?: TLSClientResponseData;
+  getDeviceTokenResponse?: TLSClientResponseData;
 }) {
   return {
     startSession: {
@@ -59,7 +61,7 @@ export function unexpectedResponse({
       response: {
         status: 200,
         headers: {},
-        body: {
+        body: getDeviceTokenResponse ?? {
           status: 200,
           cookies: {
             "session-id": faker.string.uuid(),

--- a/src/book.ts
+++ b/src/book.ts
@@ -3,6 +3,7 @@ import {
   KindleOwnedBookMetadataResponse,
 } from "./book-metadata.js";
 import { HttpClient } from "./http-client.js";
+import { UnexpectedResponseError } from "./kindle.js";
 
 export class KindleBook {
   public readonly title: string;
@@ -45,6 +46,10 @@ export class KindleBook {
         this.asin
       }&clientVersion=${this.#version}`
     );
+    if (!UnexpectedResponseError.isOk(response)) {
+      throw UnexpectedResponseError.unexpectedStatusCode(response);
+    }
+
     const info = JSON.parse(response.body) as KindleOwnedBookMetadataResponse;
 
     return {
@@ -79,6 +84,10 @@ export class KindleBook {
   ): Promise<KindleBookDetails> {
     const info = partialDetails ?? (await this.details());
     const response = await this.#client.request(info.metadataUrl);
+
+    if (!UnexpectedResponseError.isOk(response)) {
+      throw UnexpectedResponseError.unexpectedStatusCode(response);
+    }
 
     const meta =
       this.#client.parseJsonpResponse<KindleBookMetadataResponse>(response);

--- a/src/errors/auth-session-error.ts
+++ b/src/errors/auth-session-error.ts
@@ -1,0 +1,22 @@
+import { TLSClientResponseData } from "../kindle";
+
+export class AuthSessionError extends Error {
+  constructor(message: string, public response: TLSClientResponseData) {
+    super(message);
+  }
+
+  public static isSignInRedirect(response: TLSClientResponseData): boolean {
+    return (
+      response.status === 302 &&
+      Array.isArray(response.headers.Location) &&
+      response.headers.Location.length > 0 &&
+      response.headers.Location[0].startsWith(
+        "https://www.amazon.com/ap/signin"
+      )
+    );
+  }
+
+  static sessionExpired(resp: TLSClientResponseData) {
+    return new AuthSessionError("Session expired", resp);
+  }
+}

--- a/src/errors/unexpected-response-error.ts
+++ b/src/errors/unexpected-response-error.ts
@@ -1,0 +1,18 @@
+import { TLSClientResponseData } from "../kindle";
+
+export class UnexpectedResponseError extends Error {
+  constructor(message: string, public response: TLSClientResponseData) {
+    super(message);
+  }
+
+  public static isOk(response: TLSClientResponseData): boolean {
+    return response.status >= 200 && response.status < 300;
+  }
+
+  public static unexpectedStatusCode(resp: TLSClientResponseData) {
+    return new UnexpectedResponseError(
+      `Unexpected status code: ${resp.status}`,
+      resp
+    );
+  }
+}

--- a/src/fetch-books.ts
+++ b/src/fetch-books.ts
@@ -1,4 +1,6 @@
 import { KindleBook, KindleBookData } from "./book.js";
+import { AuthSessionError } from "./errors/auth-session-error.js";
+import { UnexpectedResponseError } from "./errors/unexpected-response-error.js";
 import { HttpClient } from "./http-client.js";
 import { Kindle } from "./kindle.js";
 import { Query, Filter } from "./query-filter.js";
@@ -18,6 +20,13 @@ export async function fetchBooks(
   };
 
   const resp = await client.request(url);
+
+  if (AuthSessionError.isSignInRedirect(resp)) {
+    throw AuthSessionError.sessionExpired(resp);
+  } else if (!UnexpectedResponseError.isOk(resp)) {
+    throw UnexpectedResponseError.unexpectedStatusCode(resp);
+  }
+
   const newCookies = client.extractSetCookies(resp);
   const sessionId = newCookies["session-id"];
 

--- a/src/kindle.spec.ts
+++ b/src/kindle.spec.ts
@@ -150,6 +150,35 @@ describe("unexpected response errors", () => {
     }
   );
 
+  test.each([409])(
+    "should throw when device token response status is unexpected %s",
+    async (status) => {
+      // given
+      const response = {
+        headers: {},
+        status,
+        body: "{}",
+        cookies: {},
+        target: faker.internet.url(),
+      } satisfies TLSClientResponseData;
+      useScenario(unexpectedResponse({ getDeviceTokenResponse: response }));
+
+      // when
+      const error = await getError(
+        async (): Promise<unknown> => await Kindle.fromConfig(config())
+      );
+
+      // then
+      expect(error).toBeInstanceOf(UnexpectedResponseError);
+      expect(error).toEqual(
+        expect.objectContaining({
+          message: `Unexpected status code: ${status}`,
+          response,
+        })
+      );
+    }
+  );
+
   test.each([400])(
     "should throw when book details response status is unexpected %s",
     async (status) => {

--- a/src/kindle.ts
+++ b/src/kindle.ts
@@ -29,6 +29,9 @@ export type {
   TLSClientResponseData,
 } from "./tls-client-api.js";
 
+export { AuthSessionError } from "./errors/auth-session-error.js";
+export { UnexpectedResponseError } from "./errors/unexpected-response-error.js";
+
 export type KindleConfiguration = {
   /**
    * Cookie string copied from your browser or exact

--- a/src/kindle.ts
+++ b/src/kindle.ts
@@ -1,4 +1,5 @@
 import { KindleBook } from "./book.js";
+import { UnexpectedResponseError } from "./errors/unexpected-response-error.js";
 import { fetchBooks, toUrl } from "./fetch-books.js";
 import {
   KindleRequiredCookies,
@@ -134,6 +135,11 @@ export class Kindle {
     });
     const url = `${Kindle.DEVICE_TOKEN_URL}?${params.toString()}`;
     const response = await client.request(url);
+
+    if (!UnexpectedResponseError.isOk(response)) {
+      throw UnexpectedResponseError.unexpectedStatusCode(response);
+    }
+
     return JSON.parse(response.body) as KindleDeviceInfo;
   }
 


### PR DESCRIPTION
Hi @Xetera,

While using your library, I encountered a peculiar JSON decoding error. This issue turned out to be caused by a 302 redirect response, where the Amazon server was attempting to reauthenticate the session.

To address this, I added a check to ensure the response code from Amazon is as expected (200) before parsing the JSON body. This allows callers to catch the error and respond accordingly.

Please take a look at it.

Thanks!
