### PR TITLE
Support different base URLs

### DIFF
--- a/src/book.ts
+++ b/src/book.ts
@@ -17,8 +17,14 @@ export class KindleBook {
 
   readonly #client: HttpClient;
   readonly #version: string;
+  readonly #baseUrl: string;
 
-  constructor(options: KindleBookData, client: HttpClient, version?: string) {
+  constructor(
+    options: KindleBookData,
+    client: HttpClient,
+    baseUrl: string,
+    version?: string
+  ) {
     this.title = options.title;
     this.authors = KindleBook.normalizeAuthors(options.authors);
     this.imageUrl = options.productUrl;
@@ -31,6 +37,7 @@ export class KindleBook {
 
     this.#client = client;
     this.#version = version ?? "2000010";
+    this.#baseUrl = baseUrl;
   }
 
   /**
@@ -41,7 +48,7 @@ export class KindleBook {
    */
   async details(): Promise<KindleBookLightDetails> {
     const response = await this.#client.request(
-      `https://read.amazon.com/service/mobile/reader/startReading?asin=${
+      `${this.#baseUrl}/service/mobile/reader/startReading?asin=${
         this.asin
       }&clientVersion=${this.#version}`
     );

--- a/src/fetch-books.ts
+++ b/src/fetch-books.ts
@@ -29,8 +29,8 @@ export async function fetchBooks(
   };
 }
 
-export function toUrl(query: Query, filter: Filter): string {
-  const url = new URL(Kindle.BOOKS_URL);
+export function toUrl(baseUrl: string, query: Query, filter: Filter): string {
+  const url = new URL(`${baseUrl}/${Kindle.BOOKS_PATH}`);
   const searchParams = {
     ...query,
     ...filter,

--- a/src/fetch-books.ts
+++ b/src/fetch-books.ts
@@ -6,6 +6,7 @@ import { Query, Filter } from "./query-filter.js";
 export async function fetchBooks(
   client: HttpClient,
   url: string,
+  baseUrl: string,
   version?: string
 ): Promise<{
   books: KindleBook[];
@@ -23,7 +24,9 @@ export async function fetchBooks(
 
   const body = JSON.parse(resp.body) as Response;
   return {
-    books: body.itemsList.map((book) => new KindleBook(book, client, version)),
+    books: body.itemsList.map(
+      (book) => new KindleBook(book, client, baseUrl, version)
+    ),
     sessionId,
     paginationToken: body.paginationToken,
   };

--- a/src/kindle.ts
+++ b/src/kindle.ts
@@ -188,6 +188,7 @@ export class Kindle {
       const { books, sessionId, paginationToken } = await fetchBooks(
         client,
         url,
+        baseUrl,
         version
       );
 


### PR DESCRIPTION
Hi @Xetera,

I've run into a scenario, where I need to change the base URL. First, the Kindle Cloud Reader has regional endpoints; and second, it allows local mock servers to be used without additional setup.

Best regards,

Gitii